### PR TITLE
fix(match-name): use the jvm-name instead of the qualified-name to fix can't filter the nested class

### DIFF
--- a/kotlin-runner/src/main/kotlin/de/jodamob/kotlin/testrunner/NoMoreFinalsClassLoader.kt
+++ b/kotlin-runner/src/main/kotlin/de/jodamob/kotlin/testrunner/NoMoreFinalsClassLoader.kt
@@ -76,7 +76,7 @@ internal class NoMoreFinalsClassLoader(val classFilter: ClassFilter, val rootCla
     }
 
     private fun isIncluded(className: String)
-            = className.isInProcessedPackage(classFilter.packages) || classFilter.classes.any { it.qualifiedName == className }
+            = className.isInProcessedPackage(classFilter.packages) || classFilter.classes.any { it.jvmName == className }
 
     private fun isRootClass(className: String) = className == rootClass.canonicalName
 }


### PR DESCRIPTION
#### Thanks for this great project!

But when I use it, I find it nothing to do when I defined a nested class:

```kotlin
@OpenedClasses(FileEngineImplTest.StamperConfigGeneratePayload::class)
```

So I debug it, and find the class loader load a class with its `jvm-name` rather than `qualified-name`, so I fix it. 

Hope this project will be better and better.