### PR TITLE
java.lang.ClassNotFoundException is expected by dagger1 to create empty InjectAdapter

### DIFF
--- a/kotlin-runner/src/main/kotlin/de/jodamob/kotlin/testrunner/NoMoreFinalsClassLoader.kt
+++ b/kotlin-runner/src/main/kotlin/de/jodamob/kotlin/testrunner/NoMoreFinalsClassLoader.kt
@@ -30,11 +30,15 @@ internal class NoMoreFinalsClassLoader(val classFilter: ClassFilter, val rootCla
     @Suppress("UNCHECKED_CAST")
     @Throws(Exception::class)
     fun <T> process(className: String): Class<T> {
-        val defaultClass = pool.get(className)
-        return if (isIncluded(className) && !isStaticOrNotPublic(className, defaultClass)) {
-            removeFinal(defaultClass) as Class<T>
-        } else {
-            defaultClass.toClass(this) as Class<T>
+        try {
+            val defaultClass = pool.get(className)
+            return if (isIncluded(className) && !isStaticOrNotPublic(className, defaultClass)) {
+                removeFinal(defaultClass) as Class<T>
+            } else {
+                defaultClass.toClass(this) as Class<T>
+            }
+        } catch (notFound: javassist.NotFoundException) {
+           throw ClassNotFoundException(notFound.message)
         }
     }
 

--- a/kotlin-runner/src/main/kotlin/de/jodamob/kotlin/testrunner/NoMoreFinalsClassLoader.kt
+++ b/kotlin-runner/src/main/kotlin/de/jodamob/kotlin/testrunner/NoMoreFinalsClassLoader.kt
@@ -11,6 +11,7 @@ internal class NoMoreFinalsClassLoader(val classFilter: ClassFilter, val rootCla
 
     private val pool = ClassPool(false)
     private val processedPackages: List<String>
+    private val loadedClasses = mutableMapOf<String, Class<*>>()
 
     init {
         pool.appendClassPath(LoaderClassPath(this))
@@ -32,13 +33,15 @@ internal class NoMoreFinalsClassLoader(val classFilter: ClassFilter, val rootCla
     fun <T> process(className: String): Class<T> {
         try {
             val defaultClass = pool.get(className)
-            return if (isIncluded(className) && !isStaticOrNotPublic(className, defaultClass)) {
-                removeFinal(defaultClass) as Class<T>
-            } else {
-                defaultClass.toClass(this) as Class<T>
-            }
+            return loadedClasses.getOrPut(className, {
+                if (isIncluded(className) && !isStaticOrNotPublic(className, defaultClass)) {
+                    removeFinal(defaultClass) as Class<T>
+                } else {
+                    defaultClass.toClass(this)
+                }
+            }) as Class<T>
         } catch (notFound: javassist.NotFoundException) {
-           throw ClassNotFoundException(notFound.message)
+            throw ClassNotFoundException(notFound.message)
         }
     }
 


### PR DESCRIPTION
dagger1 is expecting ClassNotFoundException not javassist.NotFoundException, probably it is the standard of java class loader