### PR TITLE
Support for super classes final methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build
+out
 .idea
 .gradle
 local.properties

--- a/kotlin-runner-junit4/src/test/kotlin/de/jodamob/kotlin/testrunner/nonopen/FinalNonOpenClassSample.kt
+++ b/kotlin-runner-junit4/src/test/kotlin/de/jodamob/kotlin/testrunner/nonopen/FinalNonOpenClassSample.kt
@@ -1,8 +1,9 @@
 package de.jodamob.kotlin.testrunner.nonopen
 
+import de.jodamob.kotlin.testrunner.sample.SuperClassSample
 import de.jodamob.kotlin.testrunner.sample.TestedClass
 
-class FinalNonOpenClassSample : TestedClass {
+class FinalNonOpenClassSample : SuperClassSample(), TestedClass {
 
     override fun finalMethod() {
         throw IllegalAccessError("you should not see this")

--- a/kotlin-runner-junit4/src/test/kotlin/de/jodamob/kotlin/testrunner/sample/ClassToBeTested.kt
+++ b/kotlin-runner-junit4/src/test/kotlin/de/jodamob/kotlin/testrunner/sample/ClassToBeTested.kt
@@ -2,7 +2,7 @@ package de.jodamob.kotlin.testrunner.sample
 
 class ClassToBeTested(val classUnderTest: TestedClass) {
 
-    fun callMe() {
-        classUnderTest.finalMethod()
-    }
+    fun callMe() = classUnderTest.finalMethod()
+
+    fun callMeSuper() = classUnderTest.superFinalMethod()
 }

--- a/kotlin-runner-junit4/src/test/kotlin/de/jodamob/kotlin/testrunner/sample/FinalClassSample.kt
+++ b/kotlin-runner-junit4/src/test/kotlin/de/jodamob/kotlin/testrunner/sample/FinalClassSample.kt
@@ -1,6 +1,6 @@
 package de.jodamob.kotlin.testrunner.sample
 
-class FinalClassSample : TestedClass {
+class FinalClassSample : SuperClassSample(), TestedClass {
 
     override fun finalMethod() {
         throw IllegalAccessError("you should not see this")

--- a/kotlin-runner-junit4/src/test/kotlin/de/jodamob/kotlin/testrunner/sample/FinalClassTwoSample.kt
+++ b/kotlin-runner-junit4/src/test/kotlin/de/jodamob/kotlin/testrunner/sample/FinalClassTwoSample.kt
@@ -5,4 +5,9 @@ class FinalClassTwoSample : TestedClass {
     override fun finalMethod() {
         throw IllegalAccessError("you should not see this")
     }
+
+    override fun superFinalMethod() {
+        throw IllegalAccessError("you should not see this")
+    }
+
 }

--- a/kotlin-runner-junit4/src/test/kotlin/de/jodamob/kotlin/testrunner/sample/SuperClassSample.kt
+++ b/kotlin-runner-junit4/src/test/kotlin/de/jodamob/kotlin/testrunner/sample/SuperClassSample.kt
@@ -1,0 +1,6 @@
+package de.jodamob.kotlin.testrunner.sample
+
+open class SuperClassSample {
+
+    fun superFinalMethod(): Unit = throw IllegalAccessError("you should not see this")
+}

--- a/kotlin-runner-junit4/src/test/kotlin/de/jodamob/kotlin/testrunner/sample/TestedClass.kt
+++ b/kotlin-runner-junit4/src/test/kotlin/de/jodamob/kotlin/testrunner/sample/TestedClass.kt
@@ -3,4 +3,6 @@ package de.jodamob.kotlin.testrunner.sample
 interface TestedClass {
 
     fun finalMethod()
+
+    fun superFinalMethod()
 }

--- a/kotlin-runner-junit4/src/test/kotlin/de/jodamob/kotlin/testrunner/tests/FinalClassSampleSamePackage.kt
+++ b/kotlin-runner-junit4/src/test/kotlin/de/jodamob/kotlin/testrunner/tests/FinalClassSampleSamePackage.kt
@@ -7,4 +7,8 @@ class FinalClassSampleSamePackage : TestedClass {
     override fun finalMethod() {
         throw IllegalAccessError("you should not see this")
     }
+
+    override fun superFinalMethod() {
+        throw IllegalAccessError("you should not see this")
+    }
 }

--- a/kotlin-runner-junit4/src/test/kotlin/de/jodamob/kotlin/testrunner/tests/TestWithRunnerOnClasses.kt
+++ b/kotlin-runner-junit4/src/test/kotlin/de/jodamob/kotlin/testrunner/tests/TestWithRunnerOnClasses.kt
@@ -20,6 +20,13 @@ class TestWithRunnerOnClasses {
         classToBeTested.callMe()
     }
 
+    @Test(expected = IllegalAccessError::class)
+    fun should_fail_for_super_class_methods_without_mock() {
+        val finalClassSample = FinalClassSample()
+        val classToBeTested = ClassToBeTested(finalClassSample)
+        classToBeTested.callMeSuper()
+    }
+
     @Test
     fun should_work() {
         val finalClassSample = org.mockito.Mockito.mock(FinalClassSample::class.java)
@@ -32,6 +39,13 @@ class TestWithRunnerOnClasses {
         val finalClassSample = org.mockito.Mockito.mock(FinalClassTwoSample::class.java)
         val classToBeTested = ClassToBeTested(finalClassSample)
         classToBeTested.callMe()
+    }
+
+    @Test
+    fun should_work_for_super_class_methods() {
+        val finalClassSample = org.mockito.Mockito.mock(FinalClassSample::class.java)
+        val classToBeTested = ClassToBeTested(finalClassSample)
+        classToBeTested.callMeSuper()
     }
 
     @Test(expected = org.mockito.exceptions.base.MockitoException::class)

--- a/kotlin-runner-spock/src/test/groovy/de/jodamob/kotlin/testrunner/sample/TestWithRunnerOnClasses.groovy
+++ b/kotlin-runner-spock/src/test/groovy/de/jodamob/kotlin/testrunner/sample/TestWithRunnerOnClasses.groovy
@@ -22,6 +22,17 @@ class TestWithRunnerOnClasses extends Specification {
         }
     }
 
+    def "should fail for super method without mock"() {
+        expect:
+        try {
+            def finalClassSample = Mock FinalClassSample
+            def classToBeTested = new ClassToBeTested(finalClassSample)
+            classToBeTested.callMeSuper()
+        } catch (Throwable error) {
+            assert error instanceof IllegalAccessError
+        }
+    }
+
     def "should mock correctly"() {
         given:
         def finalClassSample = Mock FinalClassSample
@@ -29,6 +40,18 @@ class TestWithRunnerOnClasses extends Specification {
 
         when:
         classToBeTested.callMe()
+
+        then:
+        notThrown IllegalAccessError
+    }
+
+    def "should mock parent method correctly"() {
+        given:
+        def finalClassSample = Mock FinalClassSample
+        def classToBeTested = new ClassToBeTested(finalClassSample)
+
+        when:
+        classToBeTested.callMeSuper()
 
         then:
         notThrown IllegalAccessError

--- a/kotlin-runner-spock/src/test/kotlin/de/jodamob/kotlin/testrunner/nonopen/FinalNonOpenClassSample.kt
+++ b/kotlin-runner-spock/src/test/kotlin/de/jodamob/kotlin/testrunner/nonopen/FinalNonOpenClassSample.kt
@@ -1,8 +1,9 @@
 package de.jodamob.kotlin.testrunner.nonopen
 
+import de.jodamob.kotlin.testrunner.sample.SuperClassSample
 import de.jodamob.kotlin.testrunner.sample.TestedClass
 
-class FinalNonOpenClassSample : TestedClass {
+class FinalNonOpenClassSample : SuperClassSample(), TestedClass {
 
     override fun finalMethod(): Unit = throw IllegalAccessError("you should not see this")
 }

--- a/kotlin-runner-spock/src/test/kotlin/de/jodamob/kotlin/testrunner/sample/ClassToBeTested.kt
+++ b/kotlin-runner-spock/src/test/kotlin/de/jodamob/kotlin/testrunner/sample/ClassToBeTested.kt
@@ -3,4 +3,6 @@ package de.jodamob.kotlin.testrunner.sample
 class ClassToBeTested(val classUnderTest: TestedClass) {
 
     fun callMe() = classUnderTest.finalMethod()
+
+    fun callMeSuper() = classUnderTest.superFinalMethod()
 }

--- a/kotlin-runner-spock/src/test/kotlin/de/jodamob/kotlin/testrunner/sample/FinalClassSample.kt
+++ b/kotlin-runner-spock/src/test/kotlin/de/jodamob/kotlin/testrunner/sample/FinalClassSample.kt
@@ -1,6 +1,6 @@
 package de.jodamob.kotlin.testrunner.sample
 
-class FinalClassSample : TestedClass {
+class FinalClassSample : SuperClassSample(), TestedClass {
 
     override fun finalMethod(): Unit = throw IllegalAccessError("you should not see this")
 }

--- a/kotlin-runner-spock/src/test/kotlin/de/jodamob/kotlin/testrunner/sample/SuperClassSample.kt
+++ b/kotlin-runner-spock/src/test/kotlin/de/jodamob/kotlin/testrunner/sample/SuperClassSample.kt
@@ -1,0 +1,6 @@
+package de.jodamob.kotlin.testrunner.sample
+
+open class SuperClassSample {
+
+    fun superFinalMethod(): Unit = throw IllegalAccessError("you should not see this")
+}

--- a/kotlin-runner-spock/src/test/kotlin/de/jodamob/kotlin/testrunner/sample/TestedClass.kt
+++ b/kotlin-runner-spock/src/test/kotlin/de/jodamob/kotlin/testrunner/sample/TestedClass.kt
@@ -3,4 +3,6 @@ package de.jodamob.kotlin.testrunner.sample
 interface TestedClass {
 
     fun finalMethod()
+
+    fun superFinalMethod()
 }

--- a/kotlin-runner/src/main/kotlin/de/jodamob/kotlin/testrunner/NoMoreFinalsClassLoader.kt
+++ b/kotlin-runner/src/main/kotlin/de/jodamob/kotlin/testrunner/NoMoreFinalsClassLoader.kt
@@ -64,6 +64,9 @@ internal class NoMoreFinalsClassLoader(val classFilter: ClassFilter, val rootCla
                 it.modifiers = Modifier.clear(it.modifiers, java.lang.reflect.Modifier.FINAL)
             }
         }
+        if (clazz.superclass != null) {
+            removeFinalOnMethods(clazz.superclass)
+        }
     }
 
     private fun removeFinalOnClass(clazz: CtClass) {


### PR DESCRIPTION
Fixes #22 Add support for super classes final methods
Works recursively until topmost super class is reached
This works for junit and spock test runners